### PR TITLE
Allow specifying an install prefix for goqtdrv5

### DIFF
--- a/goqtdrv5/qtdrv.pro
+++ b/goqtdrv5/qtdrv.pro
@@ -53,7 +53,9 @@ symbian {
 }
 
 unix:!symbian {
-    maemo5 {
+    !isEmpty(PREFIX) {
+        target.path = $$PREFIX
+    } else:maemo5 {
         target.path = /opt/usr/lib
     } else {
         target.path = /usr/lib


### PR DESCRIPTION
I'm not sure if this is the best way to do this (never used qmake before) but it worked for me. I just wanted to install at /usr/local/lib instead of /usr/lib.
