### PR TITLE
fixed bug with LineEdit returnPressed, new EchoMode for LineEdit

### DIFF
--- a/goqtdrv5/cdrv.h
+++ b/goqtdrv5/cdrv.h
@@ -32,6 +32,7 @@
 #include <QBrush>
 #include <QDebug>
 #include <QSizePolicy>
+#include <QLineEdit>
 
 class QDockWidget;
 class QToolBar;
@@ -41,6 +42,7 @@ class QAction;
 class QLayout;
 class QStatusBar;
 class QListWidgetItem;
+class QLineEdit;
 
 #include <stdint.h>
 #if UINTPTR_MAX == 0xffffffff
@@ -327,6 +329,18 @@ inline void drvSetAlignment(void *param,Qt::Alignment value)
 {
     *(goInt*)param = value;
 }
+
+// STS added EchoMode 2013-09-18
+inline QLineEdit::EchoMode drvGetEchoMode(void *param)
+{
+    return (QLineEdit::EchoMode)(*(goInt*)param);
+}
+
+inline void drvSetEchoMode(void *param,QLineEdit::EchoMode value)
+{
+    *(goInt*)param = value;
+}
+
 
 inline Qt::Orientation drvGetOrientation(void *param)
 {

--- a/make/ui/lineedit.lua
+++ b/make/ui/lineedit.lua
@@ -44,6 +44,8 @@ funcs = [[
 @ InputMask() (text string)
 @ SetAlignment(value Alignment)
 @ Alignment() (value Alignment)
+@ SetEchoMode(value EchoMode)		// STS added EchoMode, 2013-09-18
+@ EchoMode() (value EchoMode)
 @ SetCursorPos(pos int)
 @ CursorPos() (pos int)
 @ SetDragEnabled(b bool)
@@ -89,6 +91,8 @@ SetInputMask = "setInputMask",
 InputMask = "inputMask",
 SetAlignment = "setAlignment",
 Alignment = "alignment",
+SetEchoMode = "setEchoMode",
+EchoMode = "echoMode",
 SetCursorPos = "setCursorPosition",
 CursorPos = "cursorPosition",
 SetDragEnabled = "setDragEnabled",
@@ -120,7 +124,8 @@ QObject::connect(self,SIGNAL(editingFinished(QString)),drvNewSignal(self,a1,a2),
 ]],
 
 OnReturnPressed = [[
-QObject::connect(self,SIGNAL(returnPressed(QString)),drvNewSignal(self,a1,a2),SLOT(call(QString)));
+// STS // QObject::connect(self,SIGNAL(returnPressed(QString)),drvNewSignal(self,a1,a2),SLOT(call(QString)));
+QObject::connect(self,SIGNAL(returnPressed()),drvNewSignal(self,a1,a2),SLOT(call()));
 ]],
 
 }

--- a/qt5/uidefs.go
+++ b/qt5/uidefs.go
@@ -12,6 +12,17 @@ var (
 	EINVAL error = syscall.EINVAL
 )
 
+// STS added EchoMode, 2013-09-18
+type EchoMode int
+
+const (
+	Normal EchoMode = iota
+	NoEcho
+	Password
+	PasswordEchoOnEdit
+)
+
+
 type Alignment int
 
 const (


### PR DESCRIPTION
Hi,

as I am trying to use your code in a go project on a mac, I found an error with onreturnpressed and added the echomode, both for the widget lineedit.
